### PR TITLE
Configure DeepSource to remove Angular plugins and skip the `js/no-di…

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -17,9 +17,10 @@ name = "javascript"
 
   [analyzers.meta]
   plugins = [
-    "react",
-    "angular",
-    "angularjs"
+    "react"
+  ]
+  skip_rules = [
+    "js/no-direct-document"
   ]
   environment = [
     "nodejs",


### PR DESCRIPTION
…rect-document` rule.